### PR TITLE
feat(api): implement todo list CRUD endpoints

### DIFF
--- a/delivery/web/handlers.go
+++ b/delivery/web/handlers.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/macesz/todo-go/delivery/web/todo"
+	"github.com/macesz/todo-go/delivery/web/todolist"
 	"github.com/macesz/todo-go/delivery/web/user"
 )
 
 type ServerServices struct {
+	TodoList  todolist.TodoListService
 	Todo      todo.TodoService
 	User      user.UserService
 	TokenAuth *jwtauth.JWTAuth
@@ -26,17 +28,20 @@ func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 type Handlers struct {
-	Todo *todo.TodoHandlers
-	User *user.UserHandlers
+	TodoList *todolist.TodoListHandlers
+	Todo     *todo.TodoHandlers
+	User     *user.UserHandlers
 }
 
 func CreateHandlers(ctx context.Context, services *ServerServices) (*Handlers, error) {
+	todoListHandler := todolist.NewHandlers(services.TodoList, services.User)
 	todoHandler := todo.NewHandlers(services.Todo, services.User)      // Create handlers with the service
 	userHandler := user.NewHandlers(services.User, services.TokenAuth) // Create handlers with the service
 
 	handlers := &Handlers{
-		Todo: todoHandler,
-		User: userHandler,
+		TodoList: todoListHandler,
+		Todo:     todoHandler,
+		User:     userHandler,
 	}
 
 	return handlers, nil

--- a/delivery/web/server.go
+++ b/delivery/web/server.go
@@ -49,6 +49,14 @@ func StartServer(ctx context.Context, conf domain.Config, services *ServerServic
 
 		r.Use(middleware.AllowContentType("application/json", "text/xml"))
 
+		r.Route("/lists", func(r chi.Router) {
+			r.Get("/", handlers.TodoList.List)
+			r.Get("/{id}", handlers.TodoList.Get)
+			r.Post("/", handlers.TodoList.Create)
+			r.Put("/{id}", handlers.TodoList.Update)
+			r.Delete("/{id}", handlers.TodoList.Delete)
+		})
+
 		r.Route("/todos", func(r chi.Router) {
 			r.Get("/", handlers.Todo.ListTodos)         // List all todos
 			r.Get("/{id}", handlers.Todo.GetTodo)       // Get specific todo by ID

--- a/delivery/web/todolist/factory.go
+++ b/delivery/web/todolist/factory.go
@@ -1,0 +1,13 @@
+package todolist
+
+type TodoListHandlers struct {
+	todoListService TodoListService
+	userService     UserService
+}
+
+func NewHandlers(todoListService TodoListService, userService UserService) *TodoListHandlers {
+	return &TodoListHandlers{
+		todoListService: todoListService,
+		userService:     userService,
+	}
+}

--- a/delivery/web/todolist/handler.go
+++ b/delivery/web/todolist/handler.go
@@ -1,0 +1,35 @@
+package todolist
+
+import (
+	"net/http"
+)
+
+func (h *TodoListHandlers) List(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement list logic
+	w.WriteHeader(http.StatusNotImplemented)
+	w.Write([]byte(`{"error": "not implemented yet"}`))
+}
+
+func (h *TodoListHandlers) Get(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement get logic
+	w.WriteHeader(http.StatusNotImplemented)
+	w.Write([]byte(`{"error": "not implemented yet"}`))
+}
+
+func (h *TodoListHandlers) Create(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement create logic
+	w.WriteHeader(http.StatusNotImplemented)
+	w.Write([]byte(`{"error": "not implemented yet"}`))
+}
+
+func (h *TodoListHandlers) Update(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement update logic
+	w.WriteHeader(http.StatusNotImplemented)
+	w.Write([]byte(`{"error": "not implemented yet"}`))
+}
+
+func (h *TodoListHandlers) Delete(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement delete logic
+	w.WriteHeader(http.StatusNotImplemented)
+	w.Write([]byte(`{"error": "not implemented yet"}`))
+}

--- a/delivery/web/todolist/interfaces.go
+++ b/delivery/web/todolist/interfaces.go
@@ -7,11 +7,11 @@ import (
 )
 
 type TodoListService interface {
-	ListTodos(ctx context.Context, userID int64) ([]*domain.TodoList, error)
-	CreateTodo(ctx context.Context, userID int64, title string, color string, labels []string) (*domain.TodoList, error)
-	GetTodo(ctx context.Context, userID int64, id int64) (*domain.TodoList, error)
-	UpdateTodo(ctx context.Context, userID int64, id int64, title string, color string, labes []string) (*domain.TodoList, error)
-	DeleteTodo(ctx context.Context, userID int64, id int64) error
+	List(ctx context.Context, userID int64) ([]*domain.TodoList, error)
+	Create(ctx context.Context, userID int64, title string, color string, labels []string) (*domain.TodoList, error)
+	Get(ctx context.Context, userID int64, id int64) (*domain.TodoList, error)
+	Update(ctx context.Context, userID int64, id int64, title string, color string, labes []string) (*domain.TodoList, error)
+	Delete(ctx context.Context, userID int64, id int64) error
 }
 
 type UserService interface {


### PR DESCRIPTION
Add REST API handlers for list management with all CRUD operations. Handlers are stubbed and ready for business logic implementation.

- TodoListHandlers with 5 endpoint methods - Handler factory integration
- ServerServices updated with ListService - Routes registered in router